### PR TITLE
add support for rac, debian bullseye and ubuntu noble - both armhf and arm64

### DIFF
--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -47,6 +47,8 @@ else
     OS=$(uname -s)
 fi
 
+ARCH=$(dpkg --print-architecture)
+
 SUDO=sudo
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=''
@@ -74,7 +76,7 @@ EOF
 
     cat /etc/apt/sources.list.d/toradex.list
     apt-get -y update -qq >/dev/null
-    apt-get -y install -qq aktualizr-torizon fluent-bit rac >/dev/null
+    apt-get -y install -qq ${PKGS_TO_INSTALL} >/dev/null
 
 rm -f /etc/fluent-bit/fluent-bit.conf
     cat > /etc/fluent-bit/fluent-bit.conf <<EOF
@@ -173,6 +175,21 @@ EOF
 
 SCRIPT
 }
+
+case ${ARCH} in
+    amd64|arm64)
+        PKGS_TO_INSTALL="aktualizr-torizon fluent-bit rac"
+        ;;
+
+    armhf)
+        PKGS_TO_INSTALL="aktualizr-torizon rac"
+        ;;
+
+    *)
+        echo "${ARCH} not supported."
+        exit 1
+        ;;
+esac
 
 case ${OS} in
     ubuntu|debian)

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -177,30 +177,31 @@ SCRIPT
 case ${OS} in
     ubuntu|debian)
 
-case ${CODENAME} in
-    noble|jammy|focal)
-        install_torizon_repo "${CODENAME}" main
+        case ${CODENAME} in
+            noble|jammy|focal)
+                install_torizon_repo "${CODENAME}" main
+                ;;
+
+            bookworm)
+                install_torizon_repo stable main
+                ;;
+
+            bullseye)
+                install_torizon_repo oldstable main
+                ;;
+
+            *)
+                echo "Unsupported release: ${CODENAME} for ${OS}."
+                exit 1
+                ;;
+        esac
+
         ;;
 
-    bookworm)
-        install_torizon_repo stable main
-        ;;
-
-    bullseye)
-        install_torizon_repo oldstable main
-        ;;
-
-    *)
-        echo "Unsupported release: ${CODENAME} for ${OS}."
-        exit 1
-        ;;
-esac
-
-    ;;
     *)
         echo "${OS} not supported."
         exit 1
-    ;;
+        ;;
 esac
 
 echo "Installation of Aktualizr completed!"

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -178,7 +178,7 @@ case ${OS} in
     ubuntu|debian)
 
 case ${CODENAME} in
-    jammy|focal)
+    noble|jammy|focal)
         install_torizon_repo ${CODENAME} main
         ;;
 

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -186,6 +186,10 @@ case ${CODENAME} in
         install_torizon_repo stable main
         ;;
 
+    bullseye)
+        install_torizon_repo oldstable main
+        ;;
+
     *)
         echo "Unsupported release: ${CODENAME} for ${OS}."
         exit 1

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -26,7 +26,6 @@ echo '                  *****     ******                  '
 echo '                      ********                      '      
 echo '                                                    '      
 
-echo "You will be prompted for your password by sudo."
 
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
@@ -53,6 +52,7 @@ SUDO=sudo
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=''
 else
+    echo "You will be prompted for your password by sudo."
     # Clear any previous sudo permission
     sudo -k
 fi

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -179,7 +179,7 @@ case ${OS} in
 
 case ${CODENAME} in
     noble|jammy|focal)
-        install_torizon_repo ${CODENAME} main
+        install_torizon_repo "${CODENAME}" main
         ;;
 
     bookworm)

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -254,3 +254,5 @@ curl -fsSL https://app.torizon.io/statics/scripts/provision-device.sh | bash -s 
 SCRIPT
 
 echo "Your device is provisioned! ⭐"
+echo "Create the torizon user to be able to use remote access"
+echo "${SUDO} adduser torizon && ${SUDO} systemctl restart remote-access"

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -74,7 +74,7 @@ EOF
 
     cat /etc/apt/sources.list.d/toradex.list
     apt-get -y update -qq >/dev/null
-    apt-get -y install -qq aktualizr-torizon fluent-bit >/dev/null
+    apt-get -y install -qq aktualizr-torizon fluent-bit rac >/dev/null
 
 rm -f /etc/fluent-bit/fluent-bit.conf
     cat > /etc/fluent-bit/fluent-bit.conf <<EOF

--- a/install-torizon-plugin.sh
+++ b/install-torizon-plugin.sh
@@ -78,6 +78,7 @@ EOF
     apt-get -y update -qq >/dev/null
     apt-get -y install -qq ${PKGS_TO_INSTALL} >/dev/null
 
+if [ -f /etc/fluent-bit/fluent-bit.conf ]; then
 rm -f /etc/fluent-bit/fluent-bit.conf
     cat > /etc/fluent-bit/fluent-bit.conf <<EOF
 [SERVICE]
@@ -172,6 +173,7 @@ rm -f /etc/fluent-bit/fluent-bit.conf
     tls.crt_file /var/sota/import/client.pem
     Retry_Limit  10
 EOF
+fi
 
 SCRIPT
 }


### PR DESCRIPTION
Minor changes to add support for rac, bullseye, noble and arm64/armhf.

Note fluent-bit doesn't provide armhf builds so I've disabled its installation for armhf.

It's RFC until I test it with our feed - tomorrow after I update the feed with rac (or make @EstebanSannin test for me :-)